### PR TITLE
feat: SNS・CloudWatch・CORS・スロットリング・Cognitoメールテンプレート・Bedrock監視実装Feature/cloudwatch sns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ lambda/**/__pycache__*
 lambda/**/*.dist-info*
 lambda/idna*
 lambda/bin*
+*.tfvars
+!*.tfvars.example

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ pip install -r requirements.txt
 ### Lambdaパッケージのビルド
 
 ```bash
-cd lambda
-pip install -r ../requirements.txt -t .
-zip -r ../lambda.zip .
+mkdir -p build
+pip install -r requirements.txt -t build/
+cp lambda/main.py build/
+zip -r lambda.zip build/
+rm -rf build/
 ```
 
 ### インフラの構築

--- a/README.md
+++ b/README.md
@@ -1,30 +1,50 @@
 # 家計管理API
 
 AWS Lambda + API Gateway + DynamoDB + Bedrock を使ったサーバーレス構成の家計管理APIです。
-Terraformでインフラをコード管理し、Cognito JWT認証でエンドポイントを保護しています。
+Terraformでインフラをコードで管理し、Cognito JWT認証でエンドポイントを保護しています。
+
+## アーキテクチャ
+
+```
+クライアント
+    │
+    ▼
+API Gateway（HTTP API / JWT認証 / CORS / スロットリング）
+    │
+    ▼
+Lambda（FastAPI + Mangum）
+    ├── DynamoDB（収支データ）
+    ├── Bedrock（Claude Haiku 4.5 / 家計アドバイス）
+    └── SNS（予算オーバー通知メール）
+
+CloudWatch Logs（Lambda ログ / 30日保持）
+CloudWatch Alarm
+    ├── Lambda エラーアラーム → SNS 運用アラートトピック
+    └── Bedrock 呼び出し回数アラーム → SNS 運用アラートトピック
+```
 
 ## 使用技術
 
 | カテゴリ | 技術 |
 |----------|------|
 | バックエンド | Python / FastAPI / Mangum |
-| インフラ | AWS Lambda / API Gateway / DynamoDB / Cognito / Bedrock |
+| インフラ | AWS Lambda / API Gateway / DynamoDB / Cognito / Bedrock / SNS / CloudWatch |
 | IaC | Terraform |
 | 認証 | AWS Cognito（JWT / SRP認証） |
 | AI | Amazon Bedrock（Claude Haiku 4.5） |
 
 ## APIエンドポイント
 
-すべてのエンドポイントはCognito JWT認証が必要です。
+すべてのエンドポイントはCognito JWT認証が必要です（`Authorization: Bearer <token>`）。
 
 | メソッド | パス | 説明 |
 |----------|------|------|
-| POST | /transactions | 収支登録 |
+| POST | /transactions | 収支登録（支出登録時に予算チェック・SNS通知） |
 | GET | /transactions | 収支一覧取得 |
 | GET | /transactions/summary | 収支集計（収入・支出・残高） |
 | GET | /transactions/advice | AIによる家計アドバイス（Bedrock） |
 
-## ローカル環境のセットアップ
+## セットアップ
 
 ### 必要なもの
 
@@ -32,7 +52,14 @@ Terraformでインフラをコード管理し、Cognito JWT認証でエンドポ
 - Terraform 1.0+
 - AWS CLI（`terraform` profileの設定が必要）
 
-### 仮想環境のセットアップ
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/takatoseki0107/household-api.git
+cd household-api
+```
+
+### 2. 仮想環境のセットアップ
 
 ```bash
 python -m venv venv
@@ -40,23 +67,119 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-### Lambdaパッケージのビルド
+### 3. terraform.tfvars の作成
 
 ```bash
-mkdir -p build
-pip install -r requirements.txt -t build/
-cp lambda/main.py build/
-zip -r lambda.zip build/
-rm -rf build/
+cp terraform/terraform.tfvars.example terraform/terraform.tfvars
 ```
 
-### インフラの構築
+`terraform/terraform.tfvars` を編集して通知先メールアドレスを設定します：
+
+```hcl
+alert_email = "your-email@example.com"
+
+# 本番環境ではフロントエンドのドメインを指定する
+# allowed_origins = ["https://your-frontend-domain.com"]
+```
+
+> ⚠️ `terraform.tfvars` は `.gitignore` に含まれています。リポジトリにコミットしないでください。
+
+### 4. Lambda パッケージのビルド
+
+Linux 環境向けにビルドします（Lambda ランタイムが Linux のため必須）：
+
+```bash
+cd lambda
+pip install -r ../requirements.txt -t . \
+  --platform manylinux2014_x86_64 \
+  --only-binary=:all: \
+  --python-version 3.12
+zip -r ../lambda.zip .
+cd ..
+```
+
+### 5. インフラの構築
 
 ```bash
 cd terraform
 terraform init
 terraform apply
 ```
+
+> ⚠️ **Cognito エラーについて**: `terraform apply` 実行時に `Invalid range for token validity` エラーが表示されることがありますが、Lambda の更新には影響ありません。
+
+`terraform apply` 完了後、以下の情報が出力されます：
+
+```
+api_gateway_url      = "https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com"
+cognito_user_pool_id = "ap-northeast-1_xxxxxxxxx"
+cognito_client_id    = "xxxxxxxxxxxxxxxxxxxxxxxxxx"
+lambda_function_name = "household-api-dev"
+dynamodb_table_name  = "household-transactions"
+```
+
+### 6. SNS サブスクリプションの確認
+
+`terraform apply` 後、`alert_email` に設定したメールアドレスに AWS から確認メールが2通届きます（予算アラート・運用アラートそれぞれ）。
+メール内の **「Confirm subscription」** リンクをクリックしてサブスクリプションを有効化してください。
+
+> ⚠️ 確認前は SNS 通知が届きません。必ず両方承認してください。
+
+## 動作確認
+
+### トークンの取得
+
+```bash
+TOKEN=$(aws cognito-idp initiate-auth \
+  --auth-flow USER_PASSWORD_AUTH \
+  --auth-parameters USERNAME=<ユーザー名>,PASSWORD='<パスワード>' \
+  --client-id <cognito_client_id> \
+  --profile terraform \
+  --query 'AuthenticationResult.AccessToken' \
+  --output text)
+```
+
+> ⚠️ `USER_PASSWORD_AUTH` を使う場合は、Cognito コンソールでアプリクライアントに `ALLOW_USER_PASSWORD_AUTH` を手動で追加してください。動作確認後は必ず削除してください。
+
+### 収支の登録
+
+```bash
+curl -X POST <api_gateway_url>/transactions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"type": "expense", "amount": 3000, "category": "食費", "date": "2025-01-01"}'
+```
+
+### 一覧取得
+
+```bash
+curl <api_gateway_url>/transactions \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### 収支集計
+
+```bash
+curl <api_gateway_url>/transactions/summary \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### AIアドバイス取得
+
+```bash
+curl <api_gateway_url>/transactions/advice \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## 監視
+
+| アラーム | 条件 | 通知先 |
+|----------|------|--------|
+| Lambda エラー | 5分間で3件以上のエラー | 運用アラート SNS |
+| Bedrock 呼び出し過多 | 1時間で100回超 | 運用アラート SNS |
+| 予算オーバー | 支出合計が閾値（デフォルト: 10万円）を超過 | 予算アラート SNS |
+
+CloudWatch Logs は `/aws/lambda/household-api-dev` に30日間保持されます。
 
 ## 開発について
 

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -1,4 +1,5 @@
 import json
+import os
 import boto3
 import uuid
 from datetime import datetime, timezone
@@ -14,6 +15,10 @@ app = FastAPI()
 dynamodb = boto3.resource("dynamodb", region_name="ap-northeast-1")
 table = dynamodb.Table("household-transactions")
 bedrock = boto3.client("bedrock-runtime", region_name="ap-northeast-1")
+sns = boto3.client("sns", region_name="ap-northeast-1")
+
+SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN", "")
+BUDGET_THRESHOLD = int(os.environ.get("BUDGET_THRESHOLD", "100000"))
 
 
 class Transaction(BaseModel):
@@ -45,6 +50,23 @@ def create_transaction(body: Transaction, request: Request):
         table.put_item(Item=item)
     except ClientError:
         raise HTTPException(status_code=500, detail="サーバーエラーが発生しました")
+
+    if body.type == "expense":
+        try:
+            response = table.query(
+                KeyConditionExpression=boto3.dynamodb.conditions.Key("userId").eq(user_id)
+            )
+            items = response.get("Items", [])
+            total_expense = sum(int(i["amount"]) for i in items if i["type"] == "expense")
+            if total_expense >= BUDGET_THRESHOLD and SNS_TOPIC_ARN:
+                sns.publish(
+                    TopicArn=SNS_TOPIC_ARN,
+                    Subject="【家計管理API】予算オーバーの通知",
+                    Message=f"支出合計が予算({BUDGET_THRESHOLD:,}円)を超えました。\n現在の支出合計: {total_expense:,}円",
+                )
+        except ClientError:
+            pass
+
     return {"message": "登録しました", "transactionId": item["transactionId"]}
 
 

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import boto3
 import uuid
@@ -7,7 +8,6 @@ from fastapi import FastAPI, HTTPException, Request
 from mangum import Mangum
 from pydantic import BaseModel
 from typing import Optional, Literal
-from decimal import Decimal
 from botocore.exceptions import ClientError
 
 app = FastAPI()
@@ -17,8 +17,11 @@ table = dynamodb.Table("household-transactions")
 bedrock = boto3.client("bedrock-runtime", region_name="ap-northeast-1")
 sns = boto3.client("sns", region_name="ap-northeast-1")
 
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
 SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN", "")
-BUDGET_THRESHOLD = int(os.environ.get("BUDGET_THRESHOLD", "100000"))
+BUDGET_THRESHOLD = int(os.environ.get("BUDGET_THRESHOLD") or "100000")
 
 
 class Transaction(BaseModel):
@@ -31,6 +34,25 @@ class Transaction(BaseModel):
 
 def get_user_id(request: Request) -> str:
     return request.scope["aws.event"]["requestContext"]["authorizer"]["jwt"]["claims"]["sub"]
+
+
+def check_and_notify_budget(user_id: str) -> None:
+    """予算チェックと SNS 通知"""
+    try:
+        response = table.query(
+            KeyConditionExpression=boto3.dynamodb.conditions.Key("userId").eq(user_id)
+        )
+        items = response.get("Items", [])
+        total_expense = sum(int(i["amount"]) for i in items if i["type"] == "expense")
+        if total_expense >= BUDGET_THRESHOLD and SNS_TOPIC_ARN:
+            sns.publish(
+                TopicArn=SNS_TOPIC_ARN,
+                Subject="【家計管理API】予算オーバーの通知",
+                Message=f"支出合計が予算({BUDGET_THRESHOLD:,}円)を超えました。\n現在の支出合計: {total_expense:,}円",
+            )
+            logger.info(f"予算オーバー通知を送信しました: user={user_id}, total={total_expense}")
+    except ClientError as e:
+        logger.error(f"予算チェック/SNS通知に失敗しました: user={user_id}, error={e}")
 
 
 @app.post("/transactions")
@@ -52,20 +74,7 @@ def create_transaction(body: Transaction, request: Request):
         raise HTTPException(status_code=500, detail="サーバーエラーが発生しました")
 
     if body.type == "expense":
-        try:
-            response = table.query(
-                KeyConditionExpression=boto3.dynamodb.conditions.Key("userId").eq(user_id)
-            )
-            items = response.get("Items", [])
-            total_expense = sum(int(i["amount"]) for i in items if i["type"] == "expense")
-            if total_expense >= BUDGET_THRESHOLD and SNS_TOPIC_ARN:
-                sns.publish(
-                    TopicArn=SNS_TOPIC_ARN,
-                    Subject="【家計管理API】予算オーバーの通知",
-                    Message=f"支出合計が予算({BUDGET_THRESHOLD:,}円)を超えました。\n現在の支出合計: {total_expense:,}円",
-                )
-        except ClientError:
-            pass
+        check_and_notify_budget(user_id)
 
     return {"message": "登録しました", "transactionId": item["transactionId"]}
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,6 +8,8 @@ terraform {
   required_version = ">= 1.0"
 }
 
+data "aws_caller_identity" "current" {}
+
 provider "aws" {
   region  = "ap-northeast-1"
   profile = var.aws_profile
@@ -136,7 +138,7 @@ resource "aws_apigatewayv2_api" "household" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins = ["*"]
+    allow_origins = var.allowed_origins
     allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     allow_headers = ["Content-Type", "Authorization"]
     max_age       = 300
@@ -251,7 +253,7 @@ resource "aws_iam_policy" "lambda_bedrock" {
           "bedrock:InvokeModel"
         ]
         Resource = [
-          "arn:aws:bedrock:ap-northeast-1:028973196612:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "arn:aws:bedrock:ap-northeast-1:${data.aws_caller_identity.current.account_id}:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0",
           "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
           "arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
         ]
@@ -324,11 +326,11 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   evaluation_periods  = 1
   metric_name         = "Errors"
   namespace           = "AWS/Lambda"
-  period              = 60
+  period              = 300
   statistic           = "Sum"
-  threshold           = 0
+  threshold           = 3
   alarm_description   = "Lambda関数でエラーが発生しました"
-  alarm_actions       = [aws_sns_topic.budget_alert.arn]
+  alarm_actions       = [aws_sns_topic.ops_alert.arn]
 
   dimensions = {
     FunctionName = aws_lambda_function.household.function_name
@@ -340,8 +342,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "bedrock_errors" {
-  alarm_name          = "household-bedrock-errors-${var.environment}"
+resource "aws_cloudwatch_metric_alarm" "bedrock_invocations" {
+  alarm_name          = "household-bedrock-invocations-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "Invocations"
@@ -350,7 +352,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_errors" {
   statistic           = "Sum"
   threshold           = 100
   alarm_description   = "Bedrock呼び出し回数が1時間で100回を超えました"
-  alarm_actions       = [aws_sns_topic.budget_alert.arn]
+  alarm_actions       = [aws_sns_topic.ops_alert.arn]
 
   dimensions = {
     ModelId = "jp.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -360,4 +362,20 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_errors" {
     Name        = "household-bedrock-errors-${var.environment}"
     Environment = var.environment
   }
+}
+
+# 運用アラート（Lambdaエラー・Bedrockアラーム）用トピック
+resource "aws_sns_topic" "ops_alert" {
+  name = "household-ops-alert-${var.environment}"
+
+  tags = {
+    Name        = "household-ops-alert-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_sns_topic_subscription" "ops_alert_email" {
+  topic_arn = aws_sns_topic.ops_alert.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -359,7 +359,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_invocations" {
   }
 
   tags = {
-    Name        = "household-bedrock-errors-${var.environment}"
+    Name        = "household-bedrock-invocations-${var.environment}"
     Environment = var.environment
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,6 +52,24 @@ resource "aws_cognito_user_pool" "household" {
 
   auto_verified_attributes = ["email"]
 
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_subject        = "【家計管理API】メールアドレスの確認"
+    email_message        = "確認コード: {####}"
+  }
+
+  # schema追加はUser Pool再作成が必要なため、新規環境でのみ有効
+  # schema {
+  #   name                     = "name"
+  #   attribute_data_type      = "String"
+  #   mutable                  = true
+  #   required                 = false
+  #   string_attribute_constraints {
+  #     min_length = 1
+  #     max_length = 50
+  #   }
+  # }
+
   tags = {
     Name        = "household-user-pool-${var.environment}"
     Environment = var.environment
@@ -100,6 +118,13 @@ resource "aws_lambda_function" "household" {
   timeout          = 30
   memory_size      = 512
 
+  environment {
+    variables = {
+      SNS_TOPIC_ARN    = aws_sns_topic.budget_alert.arn
+      BUDGET_THRESHOLD = tostring(var.budget_threshold)
+    }
+  }
+
   tags = {
     Name        = "household-api-${var.environment}"
     Environment = var.environment
@@ -109,6 +134,13 @@ resource "aws_lambda_function" "household" {
 resource "aws_apigatewayv2_api" "household" {
   name          = "household-api-${var.environment}"
   protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_origins = ["*"]
+    allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    allow_headers = ["Content-Type", "Authorization"]
+    max_age       = 300
+  }
 }
 
 resource "aws_apigatewayv2_integration" "household" {
@@ -142,6 +174,11 @@ resource "aws_apigatewayv2_stage" "household" {
   api_id      = aws_apigatewayv2_api.household.id
   name        = "$default"
   auto_deploy = true
+
+  default_route_settings {
+    throttling_burst_limit = 100
+    throttling_rate_limit  = 50
+  }
 }
 
 resource "aws_lambda_permission" "household" {
@@ -230,4 +267,93 @@ resource "aws_apigatewayv2_route" "get_advice" {
   target             = "integrations/${aws_apigatewayv2_integration.household.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.household.id
+}
+
+resource "aws_sns_topic" "budget_alert" {
+  name = "household-budget-alert-${var.environment}"
+
+  tags = {
+    Name        = "household-budget-alert-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_sns_topic_subscription" "budget_alert_email" {
+  topic_arn = aws_sns_topic.budget_alert.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+resource "aws_iam_policy" "lambda_sns" {
+  name = "household-lambda-sns-policy-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["sns:Publish"]
+        Resource = aws_sns_topic.budget_alert.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_sns" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.lambda_sns.arn
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/household-api-${var.environment}"
+  retention_in_days = 30
+
+  tags = {
+    Name        = "household-api-logs-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name          = "household-lambda-errors-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "Lambda関数でエラーが発生しました"
+  alarm_actions       = [aws_sns_topic.budget_alert.arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.household.function_name
+  }
+
+  tags = {
+    Name        = "household-lambda-errors-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "bedrock_errors" {
+  alarm_name          = "household-bedrock-errors-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Invocations"
+  namespace           = "AWS/Bedrock"
+  period              = 3600
+  statistic           = "Sum"
+  threshold           = 100
+  alarm_description   = "Bedrock呼び出し回数が1時間で100回を超えました"
+  alarm_actions       = [aws_sns_topic.budget_alert.arn]
+
+  dimensions = {
+    ModelId = "jp.anthropic.claude-haiku-4-5-20251001-v1:0"
+  }
+
+  tags = {
+    Name        = "household-bedrock-errors-${var.environment}"
+    Environment = var.environment
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -250,7 +250,11 @@ resource "aws_iam_policy" "lambda_bedrock" {
         Action = [
           "bedrock:InvokeModel"
         ]
-        Resource = "arn:aws:bedrock:ap-northeast-1:028973196612:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0"
+        Resource = [
+          "arn:aws:bedrock:ap-northeast-1:028973196612:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+          "arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
+        ]
       }
     ]
   })

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "api_gateway_url" {
+  description = "API Gateway のベースURL"
+  value       = aws_apigatewayv2_api.household.api_endpoint
+}
+
+output "cognito_user_pool_id" {
+  description = "Cognito ユーザープールID"
+  value       = aws_cognito_user_pool.household.id
+}
+
+output "cognito_client_id" {
+  description = "Cognito アプリクライアントID"
+  value       = aws_cognito_user_pool_client.household.id
+}
+
+output "lambda_function_name" {
+  description = "Lambda 関数名"
+  value       = aws_lambda_function.household.function_name
+}
+
+output "dynamodb_table_name" {
+  description = "DynamoDB テーブル名"
+  value       = aws_dynamodb_table.household.name
+}
+
+output "sns_budget_alert_arn" {
+  description = "予算アラート SNS Topic ARN"
+  value       = aws_sns_topic.budget_alert.arn
+}
+
+output "sns_ops_alert_arn" {
+  description = "運用アラート SNS Topic ARN"
+  value       = aws_sns_topic.ops_alert.arn
+}
+
+output "cloudwatch_log_group" {
+  description = "Lambda CloudWatch ロググループ名"
+  value       = aws_cloudwatch_log_group.lambda.name
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# このファイルをコピーして terraform.tfvars を作成し、値を設定してください
+# cp terraform.tfvars.example terraform.tfvars
+
+alert_email = "your-email@example.com"
+
+# 本番環境ではフロントエンドのドメインを指定する
+# allowed_origins = ["https://your-frontend-domain.com"]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,3 +7,15 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "alert_email" {
+  type        = string
+  description = "予算オーバー通知先メールアドレス"
+  default     = "majesty0107@icloud.com"
+}
+
+variable "budget_threshold" {
+  type        = number
+  description = "予算オーバーとみなす支出額（円）"
+  default     = 100000
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,8 +10,13 @@ variable "environment" {
 
 variable "alert_email" {
   type        = string
-  description = "予算オーバー通知先メールアドレス"
-  default     = "majesty0107@icloud.com"
+  description = "予算オーバー通知先メールアドレス（terraform.tfvars または TF_VAR_alert_email で指定）"
+}
+
+variable "allowed_origins" {
+  type        = list(string)
+  description = "CORS許可オリジン（本番環境ではフロントエンドのドメインを指定）"
+  default     = ["*"]
 }
 
 variable "budget_threshold" {


### PR DESCRIPTION
## 概要
Issue #11 の対応。監視・通知・セキュリティ設定を追加。

## 変更内容
### Must
- SNSトピック作成・メール通知設定（予算オーバー時に通知）
- CloudWatch Logsのretention設定（30日）
- CloudWatch Metric Alarm（Lambdaエラー監視・Bedrock呼び出し回数監視）

### Should
- Cognitoメールテンプレートカスタマイズ
- API Gatewayスロットリング（burst=100・rate=50）
- CORS設定
- Bedrockの基盤モデルARN追加（ap-northeast-3対応）

### その他
- READMEビルド手順修正
- Lambda環境変数追加（SNS_TOPIC_ARN・BUDGET_THRESHOLD）

## 動作確認
- POST /transactions ✅
- GET /transactions ✅
- GET /transactions/summary ✅
- GET /transactions/advice ✅

Closes #11