### PR TITLE
fix: API 401/403エラー時に自動サインアウト・ログイン画面へリダイレクト (#19)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ export type AuthState = {
   isLoading: boolean
   idToken: string | null
   signOut: () => Promise<void>
+  handleUnauthorized: () => void
 }
 
 export const AuthContext = createContext<AuthState | null>(null)

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -32,8 +32,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIdToken(null)
   }
 
+  function handleUnauthorized() {
+    logout().catch(() => {})
+    setIsAuthenticated(false)
+    setIdToken(null)
+  }
+
   return (
-    <AuthContext.Provider value={{ isAuthenticated, isLoading, idToken, signOut }}>
+    <AuthContext.Provider value={{ isAuthenticated, isLoading, idToken, signOut, handleUnauthorized }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/pages/AdvicePage.tsx
+++ b/frontend/src/pages/AdvicePage.tsx
@@ -16,7 +16,7 @@ function Spinner() {
 }
 
 export function AdvicePage() {
-  const { idToken } = useAuth()
+  const { idToken, handleUnauthorized } = useAuth()
   const [advice, setAdvice] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -28,6 +28,7 @@ export function AdvicePage() {
       const res = await fetch(`${API_URL}/transactions/advice`, {
         headers: { Authorization: `Bearer ${idToken}` },
       })
+      if (res.status === 401 || res.status === 403) { handleUnauthorized(); return }
       if (!res.ok) throw new Error('アドバイスの取得に失敗しました')
       const data = await res.json()
       setAdvice(data.advice)

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -71,7 +71,7 @@ function buildChartData(transactions: Transaction[]): MonthlyBar[] {
 }
 
 export function DashboardPage() {
-  const { idToken } = useAuth()
+  const { idToken, handleUnauthorized } = useAuth()
   const [summary, setSummary] = useState<Summary | null>(null)
   const [chartData, setChartData] = useState<MonthlyBar[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -87,6 +87,8 @@ export function DashboardPage() {
         fetch(`${API_URL}/transactions`, { headers }),
       ])
 
+      if (summaryRes.status === 401 || summaryRes.status === 403) { handleUnauthorized(); return }
+      if (txRes.status === 401 || txRes.status === 403) { handleUnauthorized(); return }
       if (!summaryRes.ok) throw new Error('サマリーの取得に失敗しました')
       if (!txRes.ok) throw new Error('取引データの取得に失敗しました')
 

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -38,9 +38,10 @@ type EditModalProps = {
   idToken: string
   onClose: () => void
   onSaved: () => void
+  onUnauthorized: () => void
 }
 
-function EditModal({ tx, idToken, onClose, onSaved }: EditModalProps) {
+function EditModal({ tx, idToken, onClose, onSaved, onUnauthorized }: EditModalProps) {
   const [type, setType] = useState<TransactionType>(tx.type)
   const [amount, setAmount] = useState(String(tx.amount))
   const [category, setCategory] = useState(tx.category)
@@ -71,6 +72,7 @@ function EditModal({ tx, idToken, onClose, onSaved }: EditModalProps) {
         },
         body: JSON.stringify({ type, amount: Number(amount), category, date, memo: memo || null }),
       })
+      if (res.status === 401 || res.status === 403) { onUnauthorized(); return }
       if (!res.ok) throw new Error('更新に失敗しました')
       onSaved()
     } catch (err) {
@@ -211,7 +213,7 @@ function EditModal({ tx, idToken, onClose, onSaved }: EditModalProps) {
 // ── メインコンポーネント ────────────────────────────────────────────────────
 
 export function TransactionsPage() {
-  const { idToken } = useAuth()
+  const { idToken, handleUnauthorized } = useAuth()
   const [transactions, setTransactions] = useState<Transaction[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -236,6 +238,7 @@ export function TransactionsPage() {
       const res = await fetch(`${API_URL}/transactions`, {
         headers: { Authorization: `Bearer ${idToken}` },
       })
+      if (res.status === 401 || res.status === 403) { handleUnauthorized(); return }
       if (!res.ok) throw new Error('一覧の取得に失敗しました')
       const data = await res.json()
       const sorted = [...(data.transactions as Transaction[])].sort(
@@ -271,6 +274,7 @@ export function TransactionsPage() {
         },
         body: JSON.stringify({ type, amount: Number(amount), category, date, memo: memo || null }),
       })
+      if (res.status === 401 || res.status === 403) { handleUnauthorized(); return }
       if (!res.ok) throw new Error('登録に失敗しました')
       setAmount('')
       setDate(today())
@@ -302,6 +306,7 @@ export function TransactionsPage() {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${idToken}` },
       })
+      if (res.status === 401 || res.status === 403) { handleUnauthorized(); return }
       if (!res.ok) throw new Error('削除に失敗しました')
       await fetchTransactions()
     } catch (err) {
@@ -319,6 +324,7 @@ export function TransactionsPage() {
           idToken={idToken ?? ''}
           onClose={() => setEditingTx(null)}
           onSaved={() => { setEditingTx(null); void fetchTransactions() }}
+          onUnauthorized={handleUnauthorized}
         />
       )}
 


### PR DESCRIPTION
## 概要

イシュー #19 を対応します。セッション切れ等で API が 401/403 を返した際、各ページがエラー表示のまま操作不能になる問題を修正します。

## 変更内容

### `AuthContext.tsx`
- `AuthState` 型に `handleUnauthorized: () => void` を追加

### `AuthProvider.tsx`
- `handleUnauthorized` を実装：`logout()` を呼び出して認証状態（`isAuthenticated` / `idToken`）をリセット
- `signOut` と異なり `await` せず即座にリセット（API が既に無効なので `logout()` の失敗は無視して構わない）

### `DashboardPage.tsx` / `AdvicePage.tsx` / `TransactionsPage.tsx`
- 全 API リクエストに 401/403 検知を追加
- 検知したら `handleUnauthorized()` を呼んで即時リセット → `ProtectedRoute` が未認証状態を検知してログイン画面へ自動リダイレクト

### `EditModal`（`TransactionsPage.tsx` 内）
- `onUnauthorized` props を追加し、PUT リクエストにも同様の検知を追加

## テスト計画

- [ ] `npm run build` がエラーなく完了すること
- [ ] GitHub Actions CI が green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)