### PR TITLE
fix: API GatewayにDELETE・PUTルートを追加し、Cognitoパスワードポリシーを実態に合わせる

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,11 +45,11 @@ resource "aws_cognito_user_pool" "household" {
   name = "household-user-pool-${var.environment}"
 
   password_policy {
-    minimum_length    = 12
+    minimum_length    = 6
     require_uppercase = true
     require_lowercase = true
     require_numbers   = true
-    require_symbols   = true
+    require_symbols   = false
   }
 
   auto_verified_attributes = ["email"]
@@ -249,6 +249,22 @@ resource "aws_apigatewayv2_route" "get_transactions" {
 resource "aws_apigatewayv2_route" "get_transactions_summary" {
   api_id             = aws_apigatewayv2_api.household.id
   route_key          = "GET /transactions/summary"
+  target             = "integrations/${aws_apigatewayv2_integration.household.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.household.id
+}
+
+resource "aws_apigatewayv2_route" "delete_transaction" {
+  api_id             = aws_apigatewayv2_api.household.id
+  route_key          = "DELETE /transactions/{transactionId}"
+  target             = "integrations/${aws_apigatewayv2_integration.household.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.household.id
+}
+
+resource "aws_apigatewayv2_route" "put_transaction" {
+  api_id             = aws_apigatewayv2_api.household.id
+  route_key          = "PUT /transactions/{transactionId}"
   target             = "integrations/${aws_apigatewayv2_integration.household.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.household.id


### PR DESCRIPTION
## 概要

収支の削除・編集時に 404 + CORSエラーが発生していた問題を修正します。

## 原因

`DELETE /transactions/{transactionId}` と `PUT /transactions/{transactionId}` の Lambda コードは実装済みでしたが、API Gateway のルート定義が `terraform/main.tf` に存在していなかったため、リクエストが到達できず 404 になっていました。CORSエラーはその結果として発生していました。

## 変更内容

### `terraform/main.tf`
- `aws_apigatewayv2_route.delete_transaction`（`DELETE /transactions/{transactionId}`）を追加
- `aws_apigatewayv2_route.put_transaction`（`PUT /transactions/{transactionId}`）を追加
- Cognito パスワードポリシーをコード上も実態（最小6文字・記号不要）に合わせて修正

### デプロイ済み
`terraform apply` 済み。2 added, 1 changed, 0 destroyed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)