### PR TITLE
fix: メモを空にして編集しても反映されない問題を修正

### DIFF
--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -70,7 +70,7 @@ function EditModal({ tx, idToken, onClose, onSaved, onUnauthorized }: EditModalP
           Authorization: `Bearer ${idToken}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ type, amount: Number(amount), category, date, memo: memo || null }),
+        body: JSON.stringify({ type, amount: Number(amount), category, date, memo }),
       })
       if (res.status === 401 || res.status === 403) { onUnauthorized(); return }
       if (!res.ok) throw new Error('更新に失敗しました')

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -229,7 +229,7 @@ def delete_transaction(transaction_id: str, request: Request):
 def update_transaction(transaction_id: str, body: TransactionUpdate, request: Request):
     user_id = get_user_id(request)
 
-    update_fields = {k: v for k, v in body.model_dump().items() if v is not None}
+    update_fields = body.model_dump(exclude_unset=True)
     if not update_fields:
         raise HTTPException(status_code=400, detail="更新するフィールドがありません")
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -164,6 +164,17 @@ class TestTransactionUpdateModel:
         assert upd.memo == "テスト"
         assert upd.type is None
 
+    def test_empty_memo_included_when_exclude_unset(self):
+        upd = TransactionUpdate(memo="")
+        fields = upd.model_dump(exclude_unset=True)
+        assert "memo" in fields
+        assert fields["memo"] == ""
+
+    def test_unset_memo_excluded_when_exclude_unset(self):
+        upd = TransactionUpdate(amount=1000)
+        fields = upd.model_dump(exclude_unset=True)
+        assert "memo" not in fields
+
     def test_invalid_type_raises(self):
         with pytest.raises(Exception):
             TransactionUpdate(type="invalid")


### PR DESCRIPTION
## 概要

メモの内容を空にして編集を確定しても反映されない不具合を修正します。

## 原因

**フロント側：** `EditModal` で `memo: memo || null` としていたため、空文字 `""` が `null` に変換されてAPIに送られていた。

**バックエンド側：** `model_dump().items()` で `v is not None` フィルターをかけていたため、`None` が届いた `memo` はスキップされ更新対象から外れていた。

## 修正内容

| ファイル | 変更内容 |
|---|---|
| `lambda/main.py` | `model_dump(exclude_unset=True)` に変更。リクエストで送られたフィールドのみ更新対象とし、空文字も正しく更新できるようにした |
| `frontend/src/pages/TransactionsPage.tsx` | `memo: memo \|\| null` → `memo: memo` に変更。空文字をそのまま送る |
| `tests/test_logic.py` | `exclude_unset=True` の挙動を検証するテスト2件を追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)